### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/cubicle-jockey/enum_ext/security/code-scanning/1](https://github.com/cubicle-jockey/enum_ext/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow file. Since the workflow only builds and tests Rust code, it does not require write access to the repository. The minimal permissions required are `contents: read`. This block should be added at the root level of the workflow file to apply to all jobs, as none of the jobs require additional permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
